### PR TITLE
feat(shortcuts): add app shortcuts and pin-to-home-screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,18 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".CardOverlayActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.CardStore.Overlay">
+            <intent-filter>
+                <action android:name="de.pawcode.cardstore.ACTION_VIEW_CARD" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".AppLaunchTileService"
             android:exported="true"

--- a/app/src/main/java/de/pawcode/cardstore/CardOverlayActivity.kt
+++ b/app/src/main/java/de/pawcode/cardstore/CardOverlayActivity.kt
@@ -1,0 +1,150 @@
+package de.pawcode.cardstore
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import de.pawcode.cardstore.data.database.entities.CardEntity
+import de.pawcode.cardstore.data.database.repositories.CardRepository
+import de.pawcode.cardstore.data.managers.PreferencesManager
+import de.pawcode.cardstore.data.services.BiometricAuthService
+import de.pawcode.cardstore.ui.components.BiometricPlaceholder
+import de.pawcode.cardstore.ui.sheets.ViewCardSheet
+import de.pawcode.cardstore.ui.theme.CardStoreTheme
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class CardOverlayActivity : FragmentActivity() {
+    companion object {
+        const val EXTRA_CARD_ID = "card_id"
+    }
+
+    private var card by mutableStateOf<CardEntity?>(null)
+    private var isAuthenticated by mutableStateOf(false)
+    private var isLoading by mutableStateOf(true)
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val cardId = intent.getStringExtra(EXTRA_CARD_ID)
+        if (cardId == null) {
+            finish()
+            return
+        }
+
+        lifecycleScope.launch {
+            val cardRepository = CardRepository(applicationContext)
+            val cardWithLabels = cardRepository.getCardById(cardId).first()
+            if (cardWithLabels == null) {
+                finish()
+                return@launch
+            }
+            card = cardWithLabels.card
+            isLoading = false
+            checkAuthentication()
+        }
+
+        setContent {
+            CardStoreTheme {
+                if (!isLoading) {
+                    val currentCard = card
+                    if (currentCard != null) {
+                        if (isAuthenticated) {
+                            CardOverlayContent(
+                                card = currentCard,
+                                onDismiss = { finish() },
+                            )
+                        } else {
+                            BiometricPlaceholder(onRetry = { checkAuthentication() })
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        val newCardId = intent.getStringExtra(EXTRA_CARD_ID)
+        if (newCardId == null) {
+            finish()
+            return
+        }
+        isLoading = true
+        isAuthenticated = false
+        card = null
+        lifecycleScope.launch {
+            val cardRepository = CardRepository(applicationContext)
+            val cardWithLabels = cardRepository.getCardById(newCardId).first()
+            if (cardWithLabels == null) {
+                finish()
+                return@launch
+            }
+            card = cardWithLabels.card
+            isLoading = false
+            checkAuthentication()
+        }
+    }
+
+    private fun checkAuthentication() {
+        lifecycleScope.launch {
+            val preferencesManager = PreferencesManager(applicationContext)
+            val biometricEnabled = preferencesManager.biometricEnabled.first()
+            if (biometricEnabled && BiometricAuthService.isBiometricAvailable(this@CardOverlayActivity)) {
+                BiometricAuthService.authenticate(
+                    activity = this@CardOverlayActivity,
+                    title = getString(R.string.biometric_auth_title),
+                    subtitle = getString(R.string.biometric_auth_subtitle),
+                    onSuccess = { isAuthenticated = true },
+                    onError = { finish() },
+                )
+            } else {
+                isAuthenticated = true
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CardOverlayContent(card: CardEntity, onDismiss: () -> Unit) {
+    val sheetState = rememberModalBottomSheetState()
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(Color.Transparent)
+                .clickable(interactionSource = interactionSource, indication = null) { onDismiss() },
+    ) {
+        ModalBottomSheet(
+            modifier = Modifier.fillMaxHeight().windowInsetsPadding(WindowInsets.statusBars),
+            sheetState = sheetState,
+            onDismissRequest = onDismiss,
+        ) {
+            ViewCardSheet(card)
+        }
+    }
+}

--- a/app/src/main/java/de/pawcode/cardstore/CardOverlayActivity.kt
+++ b/app/src/main/java/de/pawcode/cardstore/CardOverlayActivity.kt
@@ -22,9 +22,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import de.pawcode.cardstore.data.database.entities.CardEntity
+import de.pawcode.cardstore.data.database.entities.EXAMPLE_CARD
 import de.pawcode.cardstore.data.database.repositories.CardRepository
 import de.pawcode.cardstore.data.managers.PreferencesManager
 import de.pawcode.cardstore.data.services.BiometricAuthService
@@ -53,17 +55,7 @@ class CardOverlayActivity : FragmentActivity() {
             return
         }
 
-        lifecycleScope.launch {
-            val cardRepository = CardRepository(applicationContext)
-            val cardWithLabels = cardRepository.getCardById(cardId).first()
-            if (cardWithLabels == null) {
-                finish()
-                return@launch
-            }
-            card = cardWithLabels.card
-            isLoading = false
-            checkAuthentication()
-        }
+        loadCard(cardId)
 
         setContent {
             CardStoreTheme {
@@ -95,17 +87,7 @@ class CardOverlayActivity : FragmentActivity() {
         isLoading = true
         isAuthenticated = false
         card = null
-        lifecycleScope.launch {
-            val cardRepository = CardRepository(applicationContext)
-            val cardWithLabels = cardRepository.getCardById(newCardId).first()
-            if (cardWithLabels == null) {
-                finish()
-                return@launch
-            }
-            card = cardWithLabels.card
-            isLoading = false
-            checkAuthentication()
-        }
+        loadCard(newCardId)
     }
 
     private fun checkAuthentication() {
@@ -123,6 +105,20 @@ class CardOverlayActivity : FragmentActivity() {
             } else {
                 isAuthenticated = true
             }
+        }
+    }
+
+    private fun loadCard(cardId: String) {
+        lifecycleScope.launch {
+            val cardRepository = CardRepository(applicationContext)
+            val cardWithLabels = cardRepository.getCardById(cardId).first()
+            if (cardWithLabels == null) {
+                finish()
+                return@launch
+            }
+            card = cardWithLabels.card
+            isLoading = false
+            checkAuthentication()
         }
     }
 }
@@ -146,5 +142,14 @@ private fun CardOverlayContent(card: CardEntity, onDismiss: () -> Unit) {
         ) {
             ViewCardSheet(card)
         }
+    }
+}
+
+@Preview
+@Preview(device = "id:pixel_tablet")
+@Composable
+fun PreviewCardOverlayContent() {
+    CardStoreTheme {
+        CardOverlayContent(card = EXAMPLE_CARD, onDismiss = {})
     }
 }

--- a/app/src/main/java/de/pawcode/cardstore/MainActivity.kt
+++ b/app/src/main/java/de/pawcode/cardstore/MainActivity.kt
@@ -16,6 +16,7 @@ import com.google.android.play.core.review.ReviewManager
 import com.google.android.play.core.review.ReviewManagerFactory
 import com.google.mlkit.vision.codescanner.GmsBarcodeScanning
 import de.pawcode.cardstore.data.managers.PreferencesManager
+import de.pawcode.cardstore.data.utils.updateShortcuts
 import de.pawcode.cardstore.data.services.BiometricAuthService
 import de.pawcode.cardstore.data.services.DeeplinkService
 import de.pawcode.cardstore.data.services.ReviewService
@@ -64,6 +65,8 @@ class MainActivity : FragmentActivity() {
     lifecycleScope.launch { ReviewService.reviewStatus.collect { handleReviewStatus(it) } }
 
     checkAuthentication()
+
+    lifecycleScope.launch { updateShortcuts(applicationContext) }
 
     setContent {
       CardStoreTheme {

--- a/app/src/main/java/de/pawcode/cardstore/data/services/BiometricAuthService.kt
+++ b/app/src/main/java/de/pawcode/cardstore/data/services/BiometricAuthService.kt
@@ -41,8 +41,9 @@ object BiometricAuthService {
           }
 
           override fun onAuthenticationFailed() {
+            // A single failed scan (e.g. unrecognized finger) — the BiometricPrompt UI
+            // already shows a retry option, so no action is needed here.
             super.onAuthenticationFailed()
-            onError()
           }
         },
       )

--- a/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
+++ b/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
@@ -2,12 +2,13 @@ package de.pawcode.cardstore.data.utils
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Typeface
+import androidx.compose.ui.graphics.Color
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.IconCompat
 import de.pawcode.cardstore.CardOverlayActivity
 import de.pawcode.cardstore.data.database.entities.CardEntity
@@ -15,6 +16,7 @@ import de.pawcode.cardstore.data.database.repositories.CardRepository
 import de.pawcode.cardstore.data.enums.SortAttribute
 import de.pawcode.cardstore.data.managers.PreferencesManager
 import de.pawcode.cardstore.utils.calculateCardScore
+import de.pawcode.cardstore.utils.isLightColor
 import kotlinx.coroutines.flow.first
 
 private const val MAX_SHORTCUTS = 3
@@ -68,7 +70,7 @@ suspend fun updateShortcuts(context: Context) {
 
 internal fun createShortcutIcon(card: CardEntity): IconCompat {
     val size = 108
-    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val bitmap = createBitmap(size, size)
     val canvas = Canvas(bitmap)
 
     val circlePaint =
@@ -78,10 +80,7 @@ internal fun createShortcutIcon(card: CardEntity): IconCompat {
         }
     canvas.drawCircle(54f, 54f, 36f, circlePaint)
 
-    val r = android.graphics.Color.red(card.color) / 255f
-    val g = android.graphics.Color.green(card.color) / 255f
-    val b = android.graphics.Color.blue(card.color) / 255f
-    val isLight = (0.299 * r + 0.587 * g + 0.114 * b) > 0.5
+    val isLight = isLightColor(Color(card.color))
     val textPaint =
         Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = if (isLight) android.graphics.Color.BLACK else android.graphics.Color.WHITE
@@ -94,5 +93,5 @@ internal fun createShortcutIcon(card: CardEntity): IconCompat {
     val textY = 54f - (textPaint.descent() + textPaint.ascent()) / 2f
     canvas.drawText(firstLetter, 54f, textY, textPaint)
 
-    return IconCompat.createWithAdaptiveBitmap(bitmap).also { bitmap.recycle() }
+    return IconCompat.createWithAdaptiveBitmap(bitmap)
 }

--- a/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
+++ b/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
@@ -18,7 +18,9 @@ import de.pawcode.cardstore.utils.calculateCardScore
 import kotlinx.coroutines.flow.first
 
 private const val MAX_SHORTCUTS = 3
-private const val SHORTCUT_ACTION = "de.pawcode.cardstore.ACTION_VIEW_CARD"
+internal const val SHORTCUT_ACTION = "de.pawcode.cardstore.ACTION_VIEW_CARD"
+
+internal fun cardShortcutId(cardId: String) = "card_shortcut_$cardId"
 
 suspend fun updateShortcuts(context: Context) {
     val cardRepository = CardRepository(context)
@@ -37,13 +39,13 @@ suspend fun updateShortcuts(context: Context) {
 
     val topCards = sortedCards.take(MAX_SHORTCUTS)
 
-    val newShortcutIds = topCards.map { "card_shortcut_${it.cardId}" }.toSet()
+    val newShortcutIds = topCards.map { cardShortcutId(it.cardId) }.toSet()
     val existingShortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
     val staleIds = existingShortcuts.filter { it.id !in newShortcutIds }.map { it.id }
     if (staleIds.isNotEmpty()) ShortcutManagerCompat.removeDynamicShortcuts(context, staleIds)
 
     topCards.forEach { card ->
-        val shortcutId = "card_shortcut_${card.cardId}"
+        val shortcutId = cardShortcutId(card.cardId)
         val icon = createShortcutIcon(card)
 
         val intent =
@@ -64,7 +66,7 @@ suspend fun updateShortcuts(context: Context) {
     }
 }
 
-private fun createShortcutIcon(card: CardEntity): IconCompat {
+internal fun createShortcutIcon(card: CardEntity): IconCompat {
     val size = 108
     val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
     val canvas = Canvas(bitmap)

--- a/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
+++ b/app/src/main/java/de/pawcode/cardstore/data/utils/ShortcutUpdater.kt
@@ -1,0 +1,96 @@
+package de.pawcode.cardstore.data.utils
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import de.pawcode.cardstore.CardOverlayActivity
+import de.pawcode.cardstore.data.database.entities.CardEntity
+import de.pawcode.cardstore.data.database.repositories.CardRepository
+import de.pawcode.cardstore.data.enums.SortAttribute
+import de.pawcode.cardstore.data.managers.PreferencesManager
+import de.pawcode.cardstore.utils.calculateCardScore
+import kotlinx.coroutines.flow.first
+
+private const val MAX_SHORTCUTS = 3
+private const val SHORTCUT_ACTION = "de.pawcode.cardstore.ACTION_VIEW_CARD"
+
+suspend fun updateShortcuts(context: Context) {
+    val cardRepository = CardRepository(context)
+    val preferencesManager = PreferencesManager(context)
+
+    val allCards = cardRepository.allCards.first().map { it.card }
+    val sortAttribute = preferencesManager.sortAttribute.first()
+
+    val sortedCards: List<CardEntity> =
+        when (sortAttribute) {
+            SortAttribute.INTELLIGENT -> allCards.sortedByDescending { calculateCardScore(it) }
+            SortAttribute.ALPHABETICALLY -> allCards.sortedBy { it.storeName }
+            SortAttribute.RECENTLY_USED -> allCards.sortedByDescending { it.lastUsed }
+            SortAttribute.MOST_USED -> allCards.sortedByDescending { it.useCount }
+        }
+
+    val topCards = sortedCards.take(MAX_SHORTCUTS)
+
+    val newShortcutIds = topCards.map { "card_shortcut_${it.cardId}" }.toSet()
+    val existingShortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
+    val staleIds = existingShortcuts.filter { it.id !in newShortcutIds }.map { it.id }
+    if (staleIds.isNotEmpty()) ShortcutManagerCompat.removeDynamicShortcuts(context, staleIds)
+
+    topCards.forEach { card ->
+        val shortcutId = "card_shortcut_${card.cardId}"
+        val icon = createShortcutIcon(card)
+
+        val intent =
+            Intent(context, CardOverlayActivity::class.java).apply {
+                action = SHORTCUT_ACTION
+                putExtra(CardOverlayActivity.EXTRA_CARD_ID, card.cardId)
+            }
+
+        val shortcut =
+            ShortcutInfoCompat.Builder(context, shortcutId)
+                .setShortLabel(card.storeName.take(25))
+                .setLongLabel(card.storeName)
+                .setIcon(icon)
+                .setIntent(intent)
+                .build()
+
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+    }
+}
+
+private fun createShortcutIcon(card: CardEntity): IconCompat {
+    val size = 108
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+
+    val circlePaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = card.color
+            style = Paint.Style.FILL
+        }
+    canvas.drawCircle(54f, 54f, 36f, circlePaint)
+
+    val r = android.graphics.Color.red(card.color) / 255f
+    val g = android.graphics.Color.green(card.color) / 255f
+    val b = android.graphics.Color.blue(card.color) / 255f
+    val isLight = (0.299 * r + 0.587 * g + 0.114 * b) > 0.5
+    val textPaint =
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = if (isLight) android.graphics.Color.BLACK else android.graphics.Color.WHITE
+            textSize = size * 0.45f
+            typeface = Typeface.DEFAULT_BOLD
+            textAlign = Paint.Align.CENTER
+        }
+
+    val firstLetter = card.storeName.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+    val textY = 54f - (textPaint.descent() + textPaint.ascent()) / 2f
+    canvas.drawText(firstLetter, 54f, textY, textPaint)
+
+    return IconCompat.createWithAdaptiveBitmap(bitmap).also { bitmap.recycle() }
+}

--- a/app/src/main/java/de/pawcode/cardstore/ui/screens/CardListScreen.kt
+++ b/app/src/main/java/de/pawcode/cardstore/ui/screens/CardListScreen.kt
@@ -115,6 +115,7 @@ fun CardListScreen(navigator: Navigator, viewModel: CardViewModel = viewModel())
     },
     onEditCard = { card -> navigator.navigate(ScreenCardEdit(card.cardId)) },
     onShowCard = { viewModel.addUsage(it) },
+    onPinShortcut = { viewModel.pinShortcut(it) },
     onDeleteCard = { scope.launch { viewModel.deleteCard(it) } },
     onViewLabels = { navigator.navigate(ScreenLabelList) },
     onSortChange = { scope.launch { preferencesManager.saveSortAttribute(it) } },
@@ -132,6 +133,7 @@ fun CardListScreenComponent(
   onImportCard: (importedCard: CardEntity, existingCard: CardEntity?) -> Unit,
   onEditCard: (CardEntity) -> Unit,
   onShowCard: (CardEntity) -> Unit,
+  onPinShortcut: (CardEntity) -> Unit,
   onDeleteCard: (CardEntity) -> Unit,
   onViewLabels: () -> Unit,
   onSortChange: (SortAttribute) -> Unit,
@@ -325,6 +327,14 @@ fun CardListScreenComponent(
               },
             ),
             Option(
+              label = stringResource(R.string.shortcut_pin_to_home),
+              icon = R.drawable.keep_solid,
+              onClick = {
+                onPinShortcut(it)
+                showCardOptionSheet = null
+              },
+            ),
+            Option(
               label = stringResource(R.string.card_delete_title),
               icon = R.drawable.delete_forever_solid,
               onClick = {
@@ -437,6 +447,7 @@ fun PreviewCardListScreenComponent() {
     onImportCard = { _, _ -> },
     onEditCard = {},
     onShowCard = {},
+    onPinShortcut = {},
     onDeleteCard = {},
     onViewLabels = {},
     onSortChange = {},
@@ -456,6 +467,7 @@ fun PreviewCardListScreenComponentEmpty() {
     onImportCard = { _, _ -> },
     onEditCard = {},
     onShowCard = {},
+    onPinShortcut = {},
     onDeleteCard = {},
     onViewLabels = {},
     onSortChange = {},

--- a/app/src/main/java/de/pawcode/cardstore/ui/viewmodels/CardViewModel.kt
+++ b/app/src/main/java/de/pawcode/cardstore/ui/viewmodels/CardViewModel.kt
@@ -8,6 +8,7 @@ import de.pawcode.cardstore.data.database.entities.CardEntity
 import de.pawcode.cardstore.data.database.entities.LabelEntity
 import de.pawcode.cardstore.data.database.repositories.CardRepository
 import de.pawcode.cardstore.data.database.repositories.LabelRepository
+import de.pawcode.cardstore.data.utils.updateShortcuts
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -49,7 +50,8 @@ class CardViewModel(application: Application) : AndroidViewModel(application) {
       val updatedCard =
         card.copy(useCount = card.useCount + 1, lastUsed = System.currentTimeMillis())
 
-      updateCard(updatedCard)
+      cardRepository.updateCard(updatedCard)
+      updateShortcuts(getApplication())
     }
 
   fun deleteCard(card: CardEntity) = viewModelScope.launch { cardRepository.deleteCard(card) }

--- a/app/src/main/res/drawable/keep_solid.xml
+++ b/app/src/main/res/drawable/keep_solid.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M640,480L720,560L720,640L520,640L520,880L480,920L440,880L440,640L240,640L240,560L320,480L320,200L280,200L280,120L680,120L680,200L640,200L640,480Z"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,6 +74,7 @@
     <string name="scan_barcode">Barcode scannen</string>
     <string name="scan_error">Fehler beim Scannen</string>
     <string name="settings">Einstellungen</string>
+    <string name="shortcut_open_card">Karte öffnen</string>
     <string name="share_card_description">Lass jemand anderen diesen QR-Code scannen, um diese Karte zu importieren.</string>
     <string name="share_card_title">Teile deine Karte</string>
     <string name="sort_alphabetically">Alphabetisch</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -75,6 +75,7 @@
     <string name="scan_error">Fehler beim Scannen</string>
     <string name="settings">Einstellungen</string>
     <string name="shortcut_open_card">Karte öffnen</string>
+    <string name="shortcut_pin_to_home">Zum Startbildschirm hinzufügen</string>
     <string name="share_card_description">Lass jemand anderen diesen QR-Code scannen, um diese Karte zu importieren.</string>
     <string name="share_card_title">Teile deine Karte</string>
     <string name="sort_alphabetically">Alphabetisch</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="scan_barcode">Scan barcode</string>
     <string name="scan_error">Error while trying to scan barcode</string>
     <string name="settings">App settings</string>
+    <string name="shortcut_open_card">Open card</string>
     <string name="share_card_description">Let someone else scan this QR code to import this card.</string>
     <string name="share_card_title">Share your card</string>
     <string name="sort_alphabetically">Alphabetically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="scan_error">Error while trying to scan barcode</string>
     <string name="settings">App settings</string>
     <string name="shortcut_open_card">Open card</string>
+    <string name="shortcut_pin_to_home">Add to home screen</string>
     <string name="share_card_description">Let someone else scan this QR code to import this card.</string>
     <string name="share_card_title">Share your card</string>
     <string name="sort_alphabetically">Alphabetically</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,12 @@
 
     <style name="Theme.CardStore" parent="android:Theme.Material.Light.NoActionBar" />
 
+    <style name="Theme.CardStore.Overlay" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation.Dialog</item>
+    </style>
+
     <style name="Theme.AppSplash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@android:color/system_accent1_700</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>


### PR DESCRIPTION
## Summary

- Add `CardOverlayActivity` — a transparent bottom-sheet overlay that opens a specific card directly from a launcher shortcut, with biometric auth support
- Wire dynamic shortcuts (top-3 cards by score) to app startup and card usage events via `ShortcutUpdater`
- Add "Add to home screen" option to the card long-press menu that pins a launcher shortcut for that card using `ShortcutManagerCompat.requestPinShortcut`

## Key implementation details

- Shortcut intent uses a dedicated `ACTION_VIEW_CARD` action and `card_id` extra; `CardOverlayActivity` handles both `onCreate` and `onNewIntent` (for `singleTask` re-launch)
- Shortcut icon reuses `createShortcutIcon` (adaptive bitmap with card color + first letter); text contrast determined by `isLightColor` utility
- Shared `cardShortcutId(cardId)` helper ensures dynamic and pinned shortcuts for the same card share an ID

## Changes

- `CardOverlayActivity.kt` — new transparent Activity with bottom-sheet UI and biometric guard
- `ShortcutUpdater.kt` — utility to push/remove dynamic shortcuts and create adaptive bitmap icons
- `CardViewModel.kt` — `pinShortcut(card)` method; `addUsage` now triggers shortcut refresh
- `CardListScreen.kt` — "Add to home screen" option in card long-press menu
- `strings.xml` / `strings-de/strings.xml` — new shortcut and overlay string resources
- `AndroidManifest.xml` / themes — overlay Activity registration and transparent theme

## Test plan

- [ ] Launch app — dynamic shortcuts for top cards appear in launcher long-press
- [ ] Use a card — shortcut list updates to reflect new usage ranking
- [ ] Long-press a card → "Add to home screen" → shortcut pinned to launcher
- [ ] Tap pinned shortcut — `CardOverlayActivity` opens correct card as bottom sheet
- [ ] Tap pinned shortcut while app already open — `onNewIntent` loads correct card
- [ ] Enable biometric lock — overlay prompts for biometric before showing card
- [ ] Tap outside bottom sheet — overlay dismisses